### PR TITLE
Add order parameter to proposal list API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-02-20
+
+### Added
+- Add `order` parameter to proposal list API for custom sorting (e.g. `state_created_desc`, `created_desc`)
+
 ## [0.5.4] - 2026-02-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,6 +4,65 @@
 ![unit-tests](https://github.com/goverland-labs/goverland-core-storage/workflows/unit-tests/badge.svg)
 ![golangci-lint](https://github.com/goverland-labs/goverland-core-storage/workflows/golangci-lint/badge.svg)
 
+Core data storage service for the [Goverland](https://goverland.xyz) platform. It consumes DAO governance data from Snapshot via NATS, persists it in PostgreSQL, and exposes a gRPC API for other services.
+
+## Architecture
+
+- **gRPC API** — serves DAOs, proposals, votes, delegates, ENS names, and stats
+- **NATS consumers** — ingest events from the Snapshot data source
+- **PostgreSQL** — primary data store (via GORM)
+- **Background workers** — periodic tasks like top proposals caching, token price updates, delegate calculations
+
+## Project Structure
+
+```
+main.go                  # Entry point
+internal/
+  app.go                 # Application bootstrap
+  config/                # Environment-based configuration
+  dao/                   # DAO domain (repo, service, server, consumer)
+  proposal/              # Proposal domain
+  vote/                  # Vote domain
+  delegate/              # Delegate domain
+  ensresolver/           # ENS name resolution
+  stats/                 # Platform statistics
+  discord/               # Discord integration
+  events/                # Internal event definitions
+  pubsub/                # NATS pub/sub helpers
+  metrics/               # Prometheus metrics
+  logger/                # Zerolog logger setup
+protocol/
+  storagepb/             # Protobuf definitions and generated Go code
+pkg/
+  grpcsrv/               # gRPC server utilities
+  health/                # Health check endpoint
+  middleware/             # gRPC middleware
+  prometheus/            # Prometheus HTTP handler
+  sdk/zerion/            # Zerion API client
+resources/               # SQL migration files
+```
+
+## Build & Run
+
+```bash
+go build ./...
+go test ./...
+golangci-lint run
+```
+
+## Configuration
+
+The service is configured via environment variables (parsed with [caarlos0/env](https://github.com/caarlos0/env)):
+
+| Variable | Description |
+|---|---|
+| `LOG_LEVEL` | Zerolog level (default: `info`) |
+| `POSTGRES_DSN` | PostgreSQL connection string |
+| `NATS_URL` | NATS server URL |
+| `API_GRPC_SERVER_BIND` | gRPC listen address (default: `:11000`) |
+| `PROMETHEUS_LISTEN` | Prometheus metrics address |
+| `HEALTH_LISTEN` | Health check address |
+
 ## Contribution Rules
 
 [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/internal/delegate/service.go
+++ b/internal/delegate/service.go
@@ -170,7 +170,7 @@ func (s *Service) getInternalDelegates(ctx context.Context, req GetDelegatesRequ
 	}
 
 	var searchAddress *string
-	if req.QueryAccounts != nil && len(req.QueryAccounts) > 0 {
+	if len(req.QueryAccounts) > 0 {
 		address := strings.ToLower(req.QueryAccounts[0])
 		searchAddress = &address
 	}
@@ -201,11 +201,11 @@ func (s *Service) getInternalDelegates(ctx context.Context, req GetDelegatesRequ
 
 func (s *Service) getInternalDelegators(ctx context.Context, req GetDelegatesRequest) ([]Delegate, int32, error) {
 	var reqAddress *string
-	if req.QueryAccounts != nil && len(req.QueryAccounts) > 0 && req.QueryAccounts[0] != "" {
+	if len(req.QueryAccounts) > 0 && req.QueryAccounts[0] != "" {
 		reqAddress = &req.QueryAccounts[0]
 	}
 	var searchAddress *string
-	if req.QueryAccounts != nil && len(req.QueryAccounts) > 1 && req.QueryAccounts[1] != "" {
+	if len(req.QueryAccounts) > 1 && req.QueryAccounts[1] != "" {
 		searchAddress = &req.QueryAccounts[1]
 	}
 	delegates, err := s.repo.GetDelegatorsMixedInfo(ctx, req.DaoID, string(req.DelegationType), req.ChainID, reqAddress, searchAddress, req.Limit, req.Offset)
@@ -573,7 +573,7 @@ func (s *Service) handleERC20Delegation(_ context.Context, info ERC20Delegation,
 	logger := log.With().
 		Str("source", "handle_erc20_delegates").
 		Str("block_number", fmt.Sprintf("%d", info.BlockNumber)).
-		Str("chain_id", fmt.Sprintf("%d", info.ChainID)).
+		Str("chain_id", info.ChainID).
 		Str("delegator", info.DelegatorAddress).
 		Logger()
 
@@ -1228,15 +1228,7 @@ func (s *Service) getDelegatesMixed(ctx context.Context, req GetDelegatesMixedRe
 		}
 	}
 
-	delegates, total, err := s.getEnrichedDelegates(ctx, GetDelegatesRequest{
-		DaoID:          req.DaoID,
-		QueryAccounts:  req.QueryAccounts,
-		Sort:           req.Sort,
-		Limit:          req.Limit,
-		Offset:         req.Offset,
-		DelegationType: req.DelegationType,
-		ChainID:        req.ChainID,
-	})
+	delegates, total, err := s.getEnrichedDelegates(ctx, GetDelegatesRequest(req))
 	if err != nil {
 		return nil, fmt.Errorf("s.getEnrichedDelegates: %w", err)
 	}
@@ -1277,15 +1269,7 @@ func (s *Service) getDelegatorsMixed(ctx context.Context, req GetDelegatesMixedR
 		}
 	}
 
-	delegates, total, err := s.getEnrichedDelegators(ctx, GetDelegatesRequest{
-		DaoID:          req.DaoID,
-		QueryAccounts:  req.QueryAccounts,
-		Sort:           req.Sort,
-		Limit:          req.Limit,
-		Offset:         req.Offset,
-		DelegationType: req.DelegationType,
-		ChainID:        req.ChainID,
-	})
+	delegates, total, err := s.getEnrichedDelegators(ctx, GetDelegatesRequest(req))
 	if err != nil {
 		return nil, fmt.Errorf("s.getEnrichedDelegators: %w", err)
 	}

--- a/internal/proposal/filters.go
+++ b/internal/proposal/filters.go
@@ -94,7 +94,26 @@ var (
 		Field:     "created",
 		Direction: DirectionAsc,
 	}
+	OrderByCreatedDesc = Order{
+		Field:     "created",
+		Direction: DirectionDesc,
+	}
 )
+
+func parseOrderBy(s string) []Order {
+	switch s {
+	case "created_desc":
+		return []Order{OrderByCreatedDesc}
+	case "created_asc":
+		return []Order{OrderByCreated}
+	case "state_created_desc":
+		return []Order{OrderByStates, OrderByCreatedDesc}
+	case "votes_created":
+		return []Order{OrderByVotes, OrderByCreated}
+	default:
+		return nil
+	}
+}
 
 func (f OrderFilter) Apply(db *gorm.DB) *gorm.DB {
 	var ordering []string

--- a/internal/proposal/server.go
+++ b/internal/proposal/server.go
@@ -90,21 +90,18 @@ func (s *Server) GetByFilter(_ context.Context, req *storagepb.ProposalByFilterR
 		}
 
 		if req.GetTitle() != "" {
-			filters = append(filters,
-				TitleFilter{Title: req.GetTitle()},
-				OrderFilter{
-					Orders: []Order{
-						OrderByStates,
-						OrderByVotes,
-						OrderByCreated,
-					},
-				})
+			filters = append(filters, TitleFilter{Title: req.GetTitle()})
+		}
+
+		if orders := parseOrderBy(req.GetOrder()); orders != nil {
+			filters = append(filters, OrderFilter{Orders: orders})
+		} else if req.GetTitle() != "" {
+			filters = append(filters, OrderFilter{
+				Orders: []Order{OrderByStates, OrderByVotes, OrderByCreated},
+			})
 		} else {
 			filters = append(filters, OrderFilter{
-				Orders: []Order{
-					OrderByVotes,
-					OrderByCreated,
-				},
+				Orders: []Order{OrderByVotes, OrderByCreated},
 			})
 		}
 


### PR DESCRIPTION
## Summary
- Add `order` parameter to `GetByFilter` proposal RPC, allowing callers to specify custom sorting (e.g. `state_created_desc`, `created_desc`, `created_asc`, `votes_created`)
- When `order` is not provided, existing default sorting is preserved
- Update README with project structure and description

Closes #128

## Test plan
- [x] Verified locally with `grpcurl` — default sort unchanged, `state_created_desc` and `created_desc` return correctly ordered results
- [x] CI passes (build + lint + tests)